### PR TITLE
Fix string slice iteration

### DIFF
--- a/test.c
+++ b/test.c
@@ -232,6 +232,13 @@ void test_utf8_char_count() {
   assert(count == 5 + 1 + 12 + 1 + 5 + 1 + 2);
 }
 
+void test_utf8_slice_char_count() {
+  utf8_string ustr = make_utf8_string("Hello Здравствуйте こんにちは 🚩😁");
+  utf8_string slice = slice_utf8_string(ustr, 0, 5 + 1 + 24);
+  size_t count = utf8_char_count(slice);
+  assert(count == 5 + 1 + 12);
+}
+
 void test_is_utf8_char_boundary() {
   const char* str = "Hдこ😁";
   assert(is_utf8_char_boundary(str)); //    H
@@ -279,6 +286,14 @@ void test_nth_utf8_char_invalid_index_err() {
   assert(ch.byte_len == 0);
 }
 
+void test_slice_nth_utf8_char_invalid_index_err() {
+  utf8_string ustr = make_utf8_string("Hello Здравствуйте こんにちは 🚩😁");
+  utf8_string slice = slice_utf8_string(ustr, 0, 5 + 1 + 24);
+  utf8_char ch = nth_utf8_char(slice, 18);
+  assert(ch.str == NULL);
+  assert(ch.byte_len == 0);
+}
+
 void test_nth_utf8_char_empty_string_err() {
   utf8_string ustr = make_utf8_string("");
   utf8_char ch = nth_utf8_char(ustr, 0);
@@ -318,11 +333,13 @@ int main() {
   TEST(test_utf8_char_iter);
   TEST(test_utf8_char_count_zero);
   TEST(test_utf8_char_count);
+  TEST(test_utf8_slice_char_count);
   TEST(test_is_utf8_char_boundary);
   TEST(test_nth_utf8_char_valid_index_ok);
   TEST(test_nth_utf8_char_first_index_ok);
   TEST(test_nth_utf8_char_last_index_ok);
   TEST(test_nth_utf8_char_invalid_index_err);
+  TEST(test_slice_nth_utf8_char_invalid_index_err);
   TEST(test_nth_utf8_char_empty_string_err);
   TEST(test_unicode_code_point);
 

--- a/utf8.c
+++ b/utf8.c
@@ -154,7 +154,7 @@ void free_owned_utf8_string(owned_utf8_string* owned_str) {
 }
 
 utf8_char_iter make_utf8_char_iter(utf8_string ustr) {
-    return (utf8_char_iter) { .str = ustr.str };
+    return (utf8_char_iter) { .str = ustr.str, .terminator = &ustr.str[ustr.byte_len] };
 }
 
 bool is_utf8_char_boundary(const char* str) {
@@ -174,7 +174,7 @@ utf8_string slice_utf8_string(utf8_string ustr, size_t start_byte_index, size_t 
 }
 
 utf8_char next_utf8_char(utf8_char_iter* iter) {
-    if (*iter->str == '\0') return (utf8_char) { .str = iter->str, .byte_len = 0 };
+    if (iter->str == iter->terminator) return (utf8_char) { .str = iter->str, .byte_len = 0 };
 
     // iter->str is at the current char's starting byte (char boundary).
     const char* curr_boundary = iter->str;

--- a/utf8.h
+++ b/utf8.h
@@ -76,7 +76,8 @@ typedef struct {
  * within a UTF-8 encoded string.
  */
 typedef struct {
-    const char* str;     ///< Pointer to the current position of the iterator.
+    const char* str;           ///< Pointer to the current position of the iterator.
+    const char* terminator;    ///< Pointer to the last character in the string being iterated
 } utf8_char_iter;
 
 /**


### PR DESCRIPTION
Only considering '\0' as the end of the string caused `utf8_char_count` to return a wrong value when using a string slice and `nth_utf8_char` to return characters out of bounds of the slice. Explicitly referencing the terminating character fixes both issues.